### PR TITLE
Add simple static UI for n8n/Dify

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # my-first-repo
+
+This repository contains a very small example UI for testing requests with n8n or Dify.
+
+## Usage
+
+1. Open `frontend/index.html` in a browser.
+2. Set the **API Endpoint** to your n8n or Dify HTTP endpoint.
+3. Modify the JSON payload as needed.
+4. Click **Send** to post the request.
+5. The server response will appear below the button.
+
+This UI is purely static and uses `fetch` to perform a POST request. No additional build steps are required.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,24 @@
+async function sendRequest() {
+  const endpoint = document.getElementById('endpoint').value;
+  const payloadText = document.getElementById('payload').value;
+  let payload;
+  try {
+    payload = JSON.parse(payloadText);
+  } catch (e) {
+    document.getElementById('response').textContent = 'Invalid JSON';
+    return;
+  }
+  try {
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    const text = await res.text();
+    document.getElementById('response').textContent = text;
+  } catch (err) {
+    document.getElementById('response').textContent = 'Error: ' + err.message;
+  }
+}
+
+document.getElementById('send').addEventListener('click', sendRequest);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>n8n/Dify UI</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    #response { white-space: pre-wrap; border: 1px solid #ccc; padding: 1em; margin-top: 1em; }
+  </style>
+</head>
+<body>
+  <h1>n8n / Dify Frontend</h1>
+  <label for="endpoint">API Endpoint:</label>
+  <input type="text" id="endpoint" value="http://localhost:5678/">
+  <br><br>
+  <label for="payload">Payload (JSON):</label><br>
+  <textarea id="payload" rows="6" cols="60">{"example": "data"}</textarea><br>
+  <button id="send">Send</button>
+  <h2>Response:</h2>
+  <div id="response"></div>
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `frontend` directory with `index.html` and `app.js`
- update README with usage instructions

This adds a basic static webpage that can send POST requests to an endpoint (n8n or Dify) and display the response.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861dc789708832ba29e40e3ccb304c2